### PR TITLE
细化备份内容并整理指令目录接口

### DIFF
--- a/server/src/service/api_service.h
+++ b/server/src/service/api_service.h
@@ -1506,7 +1506,6 @@ inline void registerApiRoutes(Database& db, ConfigManager& cfg, AdapterManager& 
 
             J out = J::array();
             const auto allDefaults = i18n.flatten(loc);
-            std::set<std::string> coveredKeys;
             for (auto& c : cat) {
                 std::string descKey = c.value("descKey", "");
                 J row;
@@ -1520,12 +1519,18 @@ inline void registerApiRoutes(Database& db, ConfigManager& cfg, AdapterManager& 
                 row["category"] = c.value("category", "通用");
                 row["sources"] = c.value("sources", J::array());
                 row["example"] = c.value("example", "");
-                row["desc"] = descKey.empty() ? "" : i18n.tr(loc, descKey);
+                std::string desc;
+                if (c.contains("desc")) {
+                    if (c["desc"].is_object())
+                        desc = c["desc"].value(lang, c["desc"].value("zh-Hans", std::string()));
+                    else if (c["desc"].is_string()) desc = c["desc"].get<std::string>();
+                }
+                if (desc.empty() && !descKey.empty()) desc = i18n.tr(loc, descKey);
+                row["desc"] = desc;
                 J replies = J::array();
                 std::set<std::string> replyKeys;
                 auto appendReply = [&](const std::string& key, const std::string& example = std::string()) {
                     if (!replyKeys.insert(key).second) return;
-                    coveredKeys.insert(key);
                     std::string def = i18n.getDefault(loc, key);
                     replies.push_back(J{
                         {"key", key},
@@ -1557,59 +1562,6 @@ inline void registerApiRoutes(Database& db, ConfigManager& cfg, AdapterManager& 
                 }
                 row["replies"] = replies;
                 out.push_back(row);
-            }
-
-            // Keep every editable user-facing string reachable from a normal
-            // category, even when a newly added command has not yet been added to
-            // commands.json. Umbrella namespaces are split one level deeper so
-            // groups such as dice.brp/card.sc/dnd.rdc stay easy to find.
-            std::map<std::string, std::vector<std::pair<std::string, std::string>>> supplemental;
-            for (const auto& [key, def] : allDefaults) {
-                if (coveredKeys.count(key)) continue;
-                const size_t firstDot = key.find('.');
-                const std::string root = key.substr(0, firstDot);
-                if (root == "_meta" || root == "tplvar" || root == "legacy") continue;
-                std::string group = root;
-                if ((root == "dice" || root == "card" || root == "fun" || root == "dnd" || root == "help")
-                    && firstDot != std::string::npos) {
-                    const size_t secondDot = key.find('.', firstDot + 1);
-                    group = key.substr(0, secondDot);
-                }
-                supplemental[group].push_back({key, def});
-            }
-            auto supplementalCategory = [](const std::string& group) -> std::string {
-                const std::string root = group.substr(0, group.find('.'));
-                if (root == "dnd" || root == "setdnd" || root == "init") return "DND";
-                if (root == "setcoc") return "COC";
-                if (group == "dice.brp") return "BRP";
-                if (root == "card" || root == "pc" || root == "npc" || root == "buff") return "人物卡";
-                if (root == "game" || root == "log" || root == "ob" || root == "link") return "跑团";
-                if (root == "me" || root == "send") return "互动";
-                if (root == "fun" || root == "deck" || root == "favor" || root == "ak") return "娱乐";
-                if (root == "rule" || root == "hiy" || root == "setsn" || root == "sn") return "工具";
-                if (root == "help" || root == "helpdoc" || root == "lang" || root == "persona"
-                    || root == "self" || root == "system" || root == "event") return "系统";
-                if (root == "admin" || root == "trust" || root == "notice" || root == "alias"
-                    || root == "authorize" || root == "bot" || root == "dismiss" || root == "gate"
-                    || root == "group" || root == "master" || root == "mod" || root == "plugin"
-                    || root == "reply" || root == "welcome") return "管理";
-                return "通用";
-            };
-            for (const auto& [group, entries] : supplemental) {
-                J replies = J::array();
-                for (const auto& [key, def] : entries) {
-                    replies.push_back(J{
-                        {"key", key}, {"default", def},
-                        {"override", ov.count(key) ? J(ov[key]) : J(nullptr)},
-                        {"v2key", legacyv2::v2KeyFor(key)}, {"example", ""},
-                        {"vars", deriveVars(def)}
-                    });
-                }
-                out.push_back(J{
-                    {"cmd", group}, {"title", group + " · 其他文本"},
-                    {"category", supplementalCategory(group)}, {"sources", J::array()},
-                    {"example", ""}, {"desc", ""}, {"replies", replies}
-                });
             }
             jsonReply(ok(out), std::move(cb));
         } catch (const std::exception& e) { jsonReply(fail(e.what()), std::move(cb)); }
@@ -1794,12 +1746,14 @@ inline void registerApiRoutes(Database& db, ConfigManager& cfg, AdapterManager& 
     }, {drogon::Delete});
 
     app.registerHandler("/api/backup/config", [&cfg](Req, CB&& cb) {
+        const backup::Selection selection = backup::Selection::fromJson(
+            cfg.get<J>("backup/auto_selection", J::object()));
         jsonReply(ok(J{{"enabled", cfg.get<bool>("backup/auto_enabled", false)},
                        {"schedule", cfg.get<std::string>("backup/auto_schedule", "interval")},
                        {"intervalHours", cfg.get<int>("backup/auto_interval_hours", 24)},
                        {"dailyTime", cfg.get<std::string>("backup/auto_daily_time", "04:00")},
                        {"keepDays", cfg.get<int>("backup/auto_keep_days", 7)},
-                       {"selection", cfg.get<J>("backup/auto_selection", J::object())},
+                       {"selection", selection.toJson()},
                        {"lastAutoAt", cfg.get<long long>("backup/auto_last_at", 0)}}), std::move(cb));
     }, {drogon::Get});
     app.registerHandler("/api/backup/config", [&cfg](Req req, CB&& cb) {

--- a/server/src/service/backup_service.h
+++ b/server/src/service/backup_service.h
@@ -22,31 +22,90 @@ namespace dice::backup {
 namespace fs = std::filesystem;
 using json = nlohmann::json;
 
-// Selection mirrors the useful separation in mature dice-bot backup systems:
-// core state is always explicit, while bulky/user-managed resources can be
-// opted in independently.  All categories are enabled by default for a full
-// portable backup.
+// Each switch maps to one concrete kind of data.  In particular, transcript
+// logs, process logs, transcript images, uploaded assets and chat-media caches
+// must never be bundled under the same vague "logs/media" switch.
 struct Selection {
     bool config = true;
-    bool databases = true;
-    bool logs = true;
-    bool resources = true;
-    bool plugins = true;
-    bool media = true;
+    bool coreDatabase = true;
+    bool characterCards = true;
+    bool chatHistory = true;
+    bool gameLogs = true;
+    bool runtimeLogs = false;
+    bool auditLogs = false;
+    bool decks = true;
+    bool rules = true;
+    bool help = true;
+    bool cardTemplates = true;
+    bool jsPlugins = true;
+    bool luaMods = true;
+    bool uploadedAssets = false;
+    bool resourceImages = false;
+    bool gameLogImages = false;
+    bool chatMedia = false;
 
-    bool complete() const { return config && databases && logs && resources && plugins && media; }
-    json toJson() const { return {{"config", config}, {"databases", databases}, {"logs", logs},
-                                  {"resources", resources}, {"plugins", plugins}, {"media", media},
-                                  {"all", complete()}}; }
+    static Selection full() {
+        Selection value;
+        value.runtimeLogs = value.auditLogs = value.uploadedAssets = value.resourceImages =
+            value.gameLogImages = value.chatMedia = true;
+        return value;
+    }
+
+    bool complete() const {
+        return config && coreDatabase && characterCards && chatHistory && gameLogs && runtimeLogs && auditLogs &&
+            decks && rules && help && cardTemplates && jsPlugins && luaMods && uploadedAssets &&
+            resourceImages && gameLogImages && chatMedia;
+    }
+    json toJson() const {
+        return {{"config", config}, {"coreDatabase", coreDatabase}, {"characterCards", characterCards},
+                {"chatHistory", chatHistory}, {"gameLogs", gameLogs}, {"runtimeLogs", runtimeLogs},
+                {"auditLogs", auditLogs},
+                {"decks", decks}, {"rules", rules}, {"help", help}, {"cardTemplates", cardTemplates},
+                {"jsPlugins", jsPlugins}, {"luaMods", luaMods}, {"uploadedAssets", uploadedAssets},
+                {"resourceImages", resourceImages}, {"gameLogImages", gameLogImages},
+                {"chatMedia", chatMedia}, {"all", complete()}};
+    }
     static Selection fromJson(const json& value) {
         Selection result;
         if (!value.is_object()) return result;
+
+        // Version-2 settings used six broad switches.  Expand them first so
+        // scheduled backups and old manifests keep their original meaning;
+        // any new fine-grained key below then takes precedence.
+        if (value.contains("databases") || value.contains("logs") || value.contains("resources") ||
+            value.contains("plugins") || value.contains("media")) {
+            const bool databases = value.value("databases", true);
+            const bool logs = value.value("logs", true);
+            const bool resources = value.value("resources", true);
+            const bool plugins = value.value("plugins", true);
+            const bool media = value.value("media", true);
+            result.coreDatabase = databases;
+            result.characterCards = databases;
+            result.chatHistory = databases;
+            result.gameLogs = databases || logs; // logs.db was included by both old categories
+            result.runtimeLogs = logs;
+            result.auditLogs = logs;
+            result.decks = result.rules = result.help = result.cardTemplates = resources;
+            result.jsPlugins = result.luaMods = plugins;
+            result.uploadedAssets = result.resourceImages = result.gameLogImages = result.chatMedia = media;
+        }
         result.config = value.value("config", result.config);
-        result.databases = value.value("databases", result.databases);
-        result.logs = value.value("logs", result.logs);
-        result.resources = value.value("resources", result.resources);
-        result.plugins = value.value("plugins", result.plugins);
-        result.media = value.value("media", result.media);
+        result.coreDatabase = value.value("coreDatabase", result.coreDatabase);
+        result.characterCards = value.value("characterCards", result.characterCards);
+        result.chatHistory = value.value("chatHistory", result.chatHistory);
+        result.gameLogs = value.value("gameLogs", result.gameLogs);
+        result.runtimeLogs = value.value("runtimeLogs", result.runtimeLogs);
+        result.auditLogs = value.value("auditLogs", result.auditLogs);
+        result.decks = value.value("decks", result.decks);
+        result.rules = value.value("rules", result.rules);
+        result.help = value.value("help", result.help);
+        result.cardTemplates = value.value("cardTemplates", result.cardTemplates);
+        result.jsPlugins = value.value("jsPlugins", result.jsPlugins);
+        result.luaMods = value.value("luaMods", result.luaMods);
+        result.uploadedAssets = value.value("uploadedAssets", result.uploadedAssets);
+        result.resourceImages = value.value("resourceImages", result.resourceImages);
+        result.gameLogImages = value.value("gameLogImages", result.gameLogImages);
+        result.chatMedia = value.value("chatMedia", result.chatMedia);
         return result;
     }
 };
@@ -144,6 +203,23 @@ inline bool copyItem(const fs::path& from, const fs::path& to, std::string& erro
     return copyFileWithRetry(from, to, error);
 }
 
+/// Copy only regular files directly inside a directory.  Used to separate the
+/// exported transcript files in data/logs/ from its app/ and images/ children.
+template <class Predicate>
+inline bool copyFlatFiles(const fs::path& from, const fs::path& to, std::string& error, Predicate include) {
+    std::error_code ec;
+    if (!fs::is_directory(from, ec)) return true;
+    for (const auto& entry : fs::directory_iterator(from, ec)) {
+        if (ec) { error = "遍历 " + from.string() + " 失败: " + ec.message(); return false; }
+        if (!entry.is_regular_file(ec)) {
+            if (ec) { error = "读取 " + entry.path().string() + " 失败: " + ec.message(); return false; }
+            continue;
+        }
+        if (include(entry.path()) && !copyItem(entry.path(), to / entry.path().filename(), error)) return false;
+    }
+    return true;
+}
+
 inline std::string runCapture(const std::string& command, int& code);
 
 /// Serialize manual and scheduled backups: two concurrent createArchive calls
@@ -223,31 +299,50 @@ inline bool createArchive(Database& db, const fs::path& configPath, fs::path& ar
     if (selection.complete()) {
         if (!copyTree("data", stage / "data", error, true)) { fs::remove_all(stage, ec); return false; }
     } else {
-        if (selection.databases && fs::is_directory("data", ec)) {
-            for (const auto& entry : fs::directory_iterator("data", ec)) {
-                if (ec) break;
-                if (entry.is_regular_file(ec) && entry.path().extension() == ".db" &&
-                    !copyItem(entry.path(), stage / "data" / entry.path().filename(), error)) {
-                    fs::remove_all(stage, ec); return false;
-                }
+        auto copy = [&](const fs::path& item) {
+            return copyItem(item, stage / item, error);
+        };
+        if (selection.coreDatabase && !copyFlatFiles("data", stage / "data", error, [](const fs::path& path) {
+                if (path.extension() != ".db") return false;
+                const std::string name = path.filename().string();
+                return name != "cards.db" && name != "chat.db" && name != "logs.db" &&
+                    name != "plugins.db" && name != "lua_mod.db";
+            })) { fs::remove_all(stage, ec); return false; }
+        if (selection.characterCards && !copy("data/cards.db")) { fs::remove_all(stage, ec); return false; }
+        if (selection.chatHistory && !copy("data/chat.db")) { fs::remove_all(stage, ec); return false; }
+        if (selection.gameLogs) {
+            if (!copy("data/logs.db") || !copyFlatFiles("data/logs", stage / "data/logs", error,
+                    [](const fs::path& path) { return path.filename().string().rfind("crash_", 0) != 0; })) {
+                fs::remove_all(stage, ec); return false;
             }
         }
-        if (selection.logs) {
-            for (const auto& item : {fs::path("data/logs"), fs::path("data/audit"), fs::path("data/logs.db")})
-                if (!copyItem(item, stage / item, error)) { fs::remove_all(stage, ec); return false; }
+        if (selection.runtimeLogs) {
+            if (!copy("data/logs/app") ||
+                !copyFlatFiles("data/logs", stage / "data/logs", error,
+                    [](const fs::path& path) { return path.filename().string().rfind("crash_", 0) == 0; })) {
+                fs::remove_all(stage, ec); return false;
+            }
         }
-        if (selection.resources) {
-            for (const auto& item : {fs::path("data/decks"), fs::path("data/rules"), fs::path("data/rulepacks"),
-                                     fs::path("data/help"), fs::path("data/helpdoc"), fs::path("data/card-templates")})
-                if (!copyItem(item, stage / item, error)) { fs::remove_all(stage, ec); return false; }
+        if (selection.auditLogs && !copy("data/audit")) { fs::remove_all(stage, ec); return false; }
+        if (selection.decks && !copy("data/decks")) { fs::remove_all(stage, ec); return false; }
+        if (selection.rules && (!copy("data/rules") || !copy("data/rulepacks"))) { fs::remove_all(stage, ec); return false; }
+        if (selection.help && (!copy("data/help") || !copy("data/helpdoc"))) { fs::remove_all(stage, ec); return false; }
+        if (selection.cardTemplates && !copy("data/card-templates")) { fs::remove_all(stage, ec); return false; }
+        if (selection.jsPlugins) {
+            for (const auto& item : {fs::path("data/plugins"), fs::path("data/plugins.db"),
+                                     fs::path("data/js_kv.json"), fs::path("data/js_kv.json.bak")})
+                if (!copy(item)) { fs::remove_all(stage, ec); return false; }
         }
-        if (selection.plugins) {
-            for (const auto& item : {fs::path("data/plugins"), fs::path("data/mod")})
-                if (!copyItem(item, stage / item, error)) { fs::remove_all(stage, ec); return false; }
+        if (selection.luaMods) {
+            for (const auto& item : {fs::path("data/plugin"), fs::path("data/mod"), fs::path("data/lua_mod.db"),
+                                     fs::path("data/self_data")})
+                if (!copy(item)) { fs::remove_all(stage, ec); return false; }
         }
-        if (selection.media) {
-            for (const auto& item : {fs::path("data/images"), fs::path("data/chat_images"), fs::path("data/logs/images")})
-                if (!copyItem(item, stage / item, error)) { fs::remove_all(stage, ec); return false; }
+        if (selection.uploadedAssets && !copy("data/assets")) { fs::remove_all(stage, ec); return false; }
+        if (selection.resourceImages && !copy("data/images")) { fs::remove_all(stage, ec); return false; }
+        if (selection.gameLogImages && !copy("data/logs/images")) { fs::remove_all(stage, ec); return false; }
+        if (selection.chatMedia && (!copy("data/chat/images") || !copy("data/chat_images"))) {
+            fs::remove_all(stage, ec); return false;
         }
     }
     if (selection.config && fs::exists(configPath, ec)) {
@@ -255,7 +350,7 @@ inline bool createArchive(Database& db, const fs::path& configPath, fs::path& ar
             ? configPath : (configPath.parent_path().empty() ? fs::path("config") : configPath.parent_path());
         if (!copyTree(configDir, stage / "config", error)) { fs::remove_all(stage, ec); return false; }
     }
-    json manifest{{"format", "dice-next-backup"}, {"version", 2}, {"created_at", stamp()}, {"automatic", automatic},
+    json manifest{{"format", "dice-next-backup"}, {"version", 3}, {"created_at", stamp()}, {"automatic", automatic},
                   {"selection", selection.toJson()}, {"includes", json::array({"data", "config"})}};
     { std::ofstream f(stage / "manifest.json", std::ios::binary); f << manifest.dump(2); }
     fs::path backupDir = archiveDirectory(automatic); fs::create_directories(backupDir, ec);
@@ -273,7 +368,7 @@ inline bool createArchive(Database& db, const fs::path& configPath, fs::path& ar
 
 inline bool createArchive(Database& db, const fs::path& configPath, fs::path& archive, std::string& error,
                           bool automatic = false) {
-    return createArchive(db, configPath, archive, error, Selection{}, automatic);
+    return createArchive(db, configPath, archive, error, Selection::full(), automatic);
 }
 
 inline std::string runCapture(const std::string& command, int& code) {
@@ -379,7 +474,7 @@ inline bool stageRestoreArchive(const fs::path& archive, std::string& error) {
     try {
         std::ifstream f(stage / "manifest.json"); json manifest; f >> manifest;
         const int version = manifest.value("version", 0);
-        if (manifest.value("format", std::string()) != "dice-next-backup" || (version != 1 && version != 2))
+        if (manifest.value("format", std::string()) != "dice-next-backup" || (version != 1 && version != 2 && version != 3))
             throw std::runtime_error("format");
     } catch (...) { error = "备份清单格式不受支持"; fs::remove_all(stage, ec); return false; }
     return true;

--- a/server/tests/test_backup_service.cpp
+++ b/server/tests/test_backup_service.cpp
@@ -31,6 +31,53 @@ void writeFile(const fs::path& p, const std::string& content) {
 
 }  // namespace
 
+TEST(BackupSelection, DefaultsKeepImportantDataButSkipBulkyMedia) {
+    const backup::Selection selection;
+    ASSERT_TRUE(selection.config);
+    ASSERT_TRUE(selection.coreDatabase);
+    ASSERT_TRUE(selection.characterCards);
+    ASSERT_TRUE(selection.chatHistory);
+    ASSERT_TRUE(selection.gameLogs);
+    ASSERT_FALSE(selection.runtimeLogs);
+    ASSERT_FALSE(selection.auditLogs);
+    ASSERT_FALSE(selection.uploadedAssets);
+    ASSERT_FALSE(selection.resourceImages);
+    ASSERT_FALSE(selection.gameLogImages);
+    ASSERT_FALSE(selection.chatMedia);
+    ASSERT_FALSE(selection.complete());
+    ASSERT_TRUE(backup::Selection::full().complete());
+}
+
+TEST(BackupSelection, ExpandsLegacyBroadCategories) {
+    const auto selection = backup::Selection::fromJson({
+        {"config", true}, {"databases", true}, {"logs", false},
+        {"resources", false}, {"plugins", true}, {"media", false},
+    });
+    ASSERT_TRUE(selection.coreDatabase);
+    ASSERT_TRUE(selection.characterCards);
+    ASSERT_TRUE(selection.chatHistory);
+    ASSERT_TRUE(selection.gameLogs);       // old databases copied every *.db, including logs.db
+    ASSERT_FALSE(selection.runtimeLogs);
+    ASSERT_FALSE(selection.auditLogs);
+    ASSERT_FALSE(selection.decks);
+    ASSERT_TRUE(selection.jsPlugins);
+    ASSERT_TRUE(selection.luaMods);
+    ASSERT_FALSE(selection.gameLogImages);
+    ASSERT_FALSE(selection.chatMedia);
+}
+
+TEST(BackupSelection, FineGrainedKeysOverrideLegacyValues) {
+    const auto selection = backup::Selection::fromJson({
+        {"databases", true}, {"logs", true}, {"media", true},
+        {"gameLogs", false}, {"runtimeLogs", false}, {"auditLogs", false}, {"gameLogImages", false},
+    });
+    ASSERT_FALSE(selection.gameLogs);
+    ASSERT_FALSE(selection.runtimeLogs);
+    ASSERT_FALSE(selection.auditLogs);
+    ASSERT_FALSE(selection.gameLogImages);
+    ASSERT_TRUE(selection.chatMedia);
+}
+
 TEST(BackupCopy, FullTreeSkipsBackupsStore) {
     const fs::path root = tempRoot("backup_skip");
     std::error_code ec;
@@ -73,6 +120,28 @@ TEST(BackupCopy, SingleFileCopy) {
     std::string error;
     ASSERT_TRUE(backup::copyItem(src, dst, error));
     ASSERT_TRUE(fs::exists(dst));
+    fs::remove_all(root, ec);
+}
+
+TEST(BackupCopy, FlatFileFilterSeparatesTranscriptAndCrashLogs) {
+    const fs::path root = tempRoot("backup_log_filter");
+    std::error_code ec;
+    fs::remove_all(root, ec);
+    const fs::path logs = root / "logs";
+    writeFile(logs / "q_123_campaign.txt", "transcript");
+    writeFile(logs / "crash_20260101.txt", "crash");
+    writeFile(logs / "app" / "dice.log", "runtime");
+
+    std::string error;
+    ASSERT_TRUE(backup::copyFlatFiles(logs, root / "transcripts", error,
+        [](const fs::path& path) { return path.filename().string().rfind("crash_", 0) != 0; }));
+    ASSERT_TRUE(backup::copyFlatFiles(logs, root / "runtime", error,
+        [](const fs::path& path) { return path.filename().string().rfind("crash_", 0) == 0; }));
+    ASSERT_TRUE(fs::exists(root / "transcripts" / "q_123_campaign.txt"));
+    ASSERT_FALSE(fs::exists(root / "transcripts" / "crash_20260101.txt"));
+    ASSERT_TRUE(fs::exists(root / "runtime" / "crash_20260101.txt"));
+    ASSERT_FALSE(fs::exists(root / "runtime" / "q_123_campaign.txt"));
+    ASSERT_FALSE(fs::exists(root / "transcripts" / "app"));
     fs::remove_all(root, ec);
 }
 


### PR DESCRIPTION
## 变更内容

- 将备份选项拆分为核心数据、人物卡、聊天记录、跑团日志、运行日志、资源、插件和多类媒体
- 运行日志及占空间的图片、媒体默认不选
- 兼容旧版六类备份配置和旧备份清单
- 指令目录改为只返回 commands.json 中经过整理的项目，避免重复的“其他文本”
- 增加细分备份选择、旧配置迁移和归档内容测试

## 验证

- git diff --check 通过
- JSON 与前端联动检查通过
- C++ 完整构建仅支持 Windows/MSVC，将由仓库 CI 验证

关联前端与文档 PR 将分别提交。