### PR TITLE
fix: stabilize official bot heartbeat reporting

### DIFF
--- a/server/src/adapter/qq_official_adapter.h
+++ b/server/src/adapter/qq_official_adapter.h
@@ -369,7 +369,7 @@ private:
         gateway_=std::make_shared<QQGatewaySocket>(host,port,path,
             [self](std::string raw){ if(!self->stopping_) self->onGateway(raw); },
             [self](const std::string& error){ if(!self->stopping_) self->fail("连接 QQ Gateway 失败："+error); },
-            [self]{ if(!self->stopping_){ self->connected_=false; self->connecting_=false; }});
+            [self]{ if(!self->stopping_){ self->connected_=false; self->connecting_=false; self->scheduleGatewayReconnect(); }});
         gateway_->start();
     }
     void onGateway(const std::string& raw) {

--- a/server/src/core/command_router.h
+++ b/server/src/core/command_router.h
@@ -18,6 +18,7 @@
 #include "../storage/database.h"
 #include "rules_lock.h"
 #include "check_roll_override.h"
+#include "master_delivery.h"
 #include "../service/notice_manager.h"   // B：通知系统（权限变更等推送给骰主）
 
 #include <sqlite_orm/sqlite_orm.h>
@@ -5081,6 +5082,44 @@ private:
         } catch (...) {}
         return v;
     }
+    /// Resolve a configured delivery endpoint to the public identity created by
+    /// .bind.  Ambiguous/unbound endpoints deliberately stay distinct: equal
+    /// numbers on unrelated platforms must never be collapsed by guesswork.
+    std::string canonicalMasterId(const MasterEntry& master) const {
+        using identity::BindingStore;
+        if ((master.platform.empty() || master.platform == "onebot_v11") &&
+            BindingStore::isRealQQ(master.id)) return master.id;
+        if (master.platform.empty()) return {};
+        auto* st = db_.getStorage(); if (!st) return {};
+        try {
+            auto endpoints = st->get_all<IdentityEndpointRow>(orm::where(
+                orm::c(&IdentityEndpointRow::adapterType) == master.platform and
+                orm::c(&IdentityEndpointRow::kind) == std::string("user") and
+                orm::c(&IdentityEndpointRow::endpointId) == master.id));
+            std::set<std::string> publicIds;
+            for (const auto& endpoint : endpoints) {
+                auto identity = st->get<IdentityRow>(endpoint.identityId);
+                if (BindingStore::isRealQQ(identity.publicId)) publicIds.insert(identity.publicId);
+            }
+            if (publicIds.size() == 1) return *publicIds.begin();
+        } catch (...) {}
+        return {};
+    }
+    AdapterPtr connectedMasterAdapter(const master_delivery::Recipient& recipient) const {
+        if (!recipient.adapterId.empty()) {
+            auto adapter = adapters_.getAdapter(recipient.adapterId);
+            if (adapter && adapter->isConnected() &&
+                (recipient.platform.empty() || adapter->platform() == recipient.platform)) return adapter;
+        }
+        if (!recipient.platform.empty()) {
+            for (auto& adapter : adapters_.allAdapters())
+                if (adapter->isConnected() && adapter->platform() == recipient.platform) return adapter;
+        } else if (!recipient.canonicalId.empty()) {
+            for (auto& adapter : adapters_.allAdapters())
+                if (adapter->isConnected() && adapter->platform() == "onebot_v11") return adapter;
+        }
+        return {};
+    }
     /// 精确到账号：adapterId 非空时，账号级条目与平台级条目都命中；
     /// adapterId 为空时仅平台级/任意平台条目命中（保留旧调用语义）。
     bool isMaster(const std::string& platform, const std::string& id,
@@ -5634,19 +5673,32 @@ private:
             : i18n_.tr(loc, "send.from_group",
                   {{"group", msg.targetId}, {"user", displayName(msg)}, {"uid", msg.senderId}});
         std::string full = header + "\n" + body;
-        for (const auto& m : ms) {
-            // Deliver to each master via an adapter of their platform (fallback: origin/any).
+        std::vector<master_delivery::Recipient> recipients;
+        recipients.reserve(ms.size());
+        for (const auto& master : ms)
+            recipients.push_back({master.platform, master.adapterId, master.id, canonicalMasterId(master)});
+        for (const auto& group : master_delivery::groupRecipients(recipients)) {
+            // One bound person may have both real QQ and OpenID master entries.
+            // Pick one live route (OneBot first, QQ Official fallback) and stop.
+            const master_delivery::Recipient* selected = nullptr;
             AdapterPtr a;
-            if (!m.platform.empty())
-                for (auto& x : adapters_.allAdapters())
-                    if (x->isConnected() && x->platform() == m.platform) { a = x; break; }
+            for (int priority = 0; priority <= 2 && !a; ++priority) {
+                for (const auto& recipient : group) {
+                    if (master_delivery::transportPriority(recipient) != priority) continue;
+                    if (auto candidate = connectedMasterAdapter(recipient)) {
+                        selected = &recipient; a = std::move(candidate); break;
+                    }
+                }
+            }
+            // Preserve the old best-effort fallback for an unscoped/offline entry.
+            if (!selected) selected = &group.front();
             if (!a) a = adapters_.getAdapter(msg.adapterId);
             if (!a) for (auto& x : adapters_.allAdapters()) if (x->isConnected()) { a = x; break; }
             if (!a) continue;
             Message pm;
             pm.platform = a->platform();
             pm.type = MessageType::kPrivate;
-            pm.targetId = m.id;
+            pm.targetId = selected->id;
             pm.content = full;
             a->sendMessage(pm);
         }

--- a/server/src/core/master_delivery.h
+++ b/server/src/core/master_delivery.h
@@ -1,0 +1,47 @@
+#pragma once
+
+#include <string>
+#include <unordered_map>
+#include <vector>
+
+namespace dice::master_delivery {
+
+/// One configured master delivery endpoint. canonicalId is populated only when
+/// the identity binding store can prove that this endpoint belongs to a shared
+/// public identity (normally a real QQ number).
+struct Recipient {
+    std::string platform;
+    std::string adapterId;
+    std::string id;
+    std::string canonicalId;
+};
+
+inline std::string identityKey(const Recipient& recipient) {
+    if (!recipient.canonicalId.empty()) return "identity\x1f" + recipient.canonicalId;
+    return "endpoint\x1f" + recipient.platform + "\x1f" + recipient.adapterId + "\x1f" + recipient.id;
+}
+
+/// Preserve configured order while grouping only endpoints that are either an
+/// exact duplicate or explicitly joined by the identity binding store.
+inline std::vector<std::vector<Recipient>> groupRecipients(const std::vector<Recipient>& recipients) {
+    std::vector<std::vector<Recipient>> groups;
+    std::unordered_map<std::string, std::size_t> positions;
+    for (const auto& recipient : recipients) {
+        const std::string key = identityKey(recipient);
+        auto [it, inserted] = positions.emplace(key, groups.size());
+        if (inserted) groups.push_back({});
+        groups[it->second].push_back(recipient);
+    }
+    return groups;
+}
+
+/// Prefer a real QQ/OneBot route when several live transports represent the
+/// same person; QQ Official remains the fallback when OneBot is unavailable.
+inline int transportPriority(const Recipient& recipient) {
+    if (recipient.platform == "onebot_v11" ||
+        (recipient.platform.empty() && !recipient.canonicalId.empty())) return 0;
+    if (recipient.platform == "qq_official") return 1;
+    return 2;
+}
+
+} // namespace dice::master_delivery

--- a/server/src/service/heart_debounce.h
+++ b/server/src/service/heart_debounce.h
@@ -1,0 +1,28 @@
+#pragma once
+
+#include <string>
+
+namespace dice::heart {
+
+// Return true only after an adapter that was previously online has remained
+// offline for the full debounce window.  Seeing it online clears a pending
+// offline observation immediately.
+inline bool offlineTransitionReady(
+    const std::string& lastReportedStatus,
+    bool connected,
+    long long now,
+    long long& firstOfflineObservedAt,
+    long long debounceSeconds = 60
+) {
+    if (connected || lastReportedStatus != "online") {
+        firstOfflineObservedAt = 0;
+        return false;
+    }
+    if (firstOfflineObservedAt == 0) {
+        firstOfflineObservedAt = now;
+        return false;
+    }
+    return now - firstOfflineObservedAt >= debounceSeconds;
+}
+
+}  // namespace dice::heart

--- a/server/src/service/heart_service.h
+++ b/server/src/service/heart_service.h
@@ -11,6 +11,7 @@
 #include "../adapter/kook_adapter.h"
 #include "../adapter/qq_official_adapter.h"
 #include "ai_gateway.h"
+#include "heart_debounce.h"
 
 #include <nlohmann/json.hpp>
 #include <algorithm>
@@ -191,6 +192,11 @@ private:
         long long lastReportAt = 0;
         std::string lastReportIso;
         long long lastSwitchAt = 0;
+        // Timestamp of the first consecutive offline observation.  The old
+        // implementation compared against lastSwitchAt, so a brief gateway
+        // reconnect after a long online session could be reported offline at
+        // the very first sample instead of being debounced.
+        long long offlineObservedAt = 0;
         long long penaltyUntil = 0;
         bool permanentlyBlocked = false;
         std::string lastLoginIso;
@@ -341,9 +347,16 @@ private:
                     if (adapter->getLoginId().empty() && state.lastStatus == "unknown") continue;
                     desired = adapter->isConnected() ? "online" : "offline";
                     if (desired == "offline" && state.lastStatus == "unknown") continue;
-                    if (!bypassThrottle)
-                        shouldReport = state.lastStatus != desired ||
-                            (desired == "online" && now - state.lastReportAt >= interval());
+                    if (!bypassThrottle) {
+                        if (desired == "online") {
+                            state.offlineObservedAt = 0;
+                            shouldReport = state.lastStatus != desired ||
+                                now - state.lastReportAt >= interval();
+                        } else {
+                            shouldReport = offlineTransitionReady(
+                                state.lastStatus, false, now, state.offlineObservedAt);
+                        }
+                    }
                 }
             }
             if (shouldReport) result.push_back({Target{adapter, ""}, desired});
@@ -363,10 +376,14 @@ private:
                 auto& state = states_[id];
                 if (state.permanentlyBlocked || now < state.penaltyUntil) continue;
                 if (!bypassThrottle) {
-                    if (state.lastStatus != "online" && desired == "offline") continue;
-                    const bool switching = desired != state.lastStatus;
-                    shouldReport = switching ? (now - state.lastSwitchAt >= 60)
-                                             : (now - state.lastReportAt >= interval());
+                    if (desired == "online") {
+                        state.offlineObservedAt = 0;
+                        shouldReport = state.lastStatus != desired ||
+                            now - state.lastReportAt >= interval();
+                    } else {
+                        shouldReport = offlineTransitionReady(
+                            state.lastStatus, false, now, state.offlineObservedAt);
+                    }
                 }
             }
             if (shouldReport) result.push_back({target, desired});
@@ -590,6 +607,7 @@ private:
                 state.lastStatus = status;
                 state.lastReportAt = epoch();
                 state.lastReportIso = nowUtcIso();
+                state.offlineObservedAt = 0;
                 state.lastError.clear();
             } else {
                 state.lastError = httpStatus == 0 ? "网络请求失败" : "HTTP " + std::to_string(httpStatus);
@@ -617,6 +635,7 @@ private:
             state.lastStatus = reported;
             state.lastReportAt = now;
             state.lastReportIso = nowUtcIso();
+            state.offlineObservedAt = 0;
             state.lastError.clear();
             state.warned401 = false;
             if (reported == "offline") state.lastLoginIso.clear();

--- a/server/tests/CMakeLists.txt
+++ b/server/tests/CMakeLists.txt
@@ -15,6 +15,7 @@ set(TEST_SOURCES
     test_i18n_persona.cpp
     test_import_v2.cpp
     test_group_account_scoping.cpp
+    test_master_delivery.cpp
     test_backup_service.cpp
     test_timezone.cpp
     test_dice_expression.cpp

--- a/server/tests/CMakeLists.txt
+++ b/server/tests/CMakeLists.txt
@@ -21,6 +21,7 @@ set(TEST_SOURCES
     test_dice_expression.cpp
     test_check_roll_override.cpp
     test_markdown.cpp
+    test_heart_debounce.cpp
 
     # Project source files needed by tests
     ${CMAKE_CURRENT_SOURCE_DIR}/../src/core/causal/cooldown_manager.cpp

--- a/server/tests/test_heart_debounce.cpp
+++ b/server/tests/test_heart_debounce.cpp
@@ -1,0 +1,24 @@
+#include "test_framework.h"
+#include "../src/service/heart_debounce.h"
+
+TEST(HeartDebounce, RequiresContinuousOfflineWindow) {
+    long long observedAt = 0;
+    ASSERT_FALSE(dice::heart::offlineTransitionReady("online", false, 100, observedAt));
+    ASSERT_EQ(observedAt, 100LL);
+    ASSERT_FALSE(dice::heart::offlineTransitionReady("online", false, 159, observedAt));
+    ASSERT_TRUE(dice::heart::offlineTransitionReady("online", false, 160, observedAt));
+}
+
+TEST(HeartDebounce, ReconnectionCancelsPendingOffline) {
+    long long observedAt = 100;
+    ASSERT_FALSE(dice::heart::offlineTransitionReady("online", true, 130, observedAt));
+    ASSERT_EQ(observedAt, 0LL);
+    ASSERT_FALSE(dice::heart::offlineTransitionReady("online", false, 140, observedAt));
+    ASSERT_EQ(observedAt, 140LL);
+}
+
+TEST(HeartDebounce, NeverReportsInitialOfflineState) {
+    long long observedAt = 0;
+    ASSERT_FALSE(dice::heart::offlineTransitionReady("unknown", false, 100, observedAt));
+    ASSERT_EQ(observedAt, 0LL);
+}

--- a/server/tests/test_master_delivery.cpp
+++ b/server/tests/test_master_delivery.cpp
@@ -1,0 +1,38 @@
+#include "test_framework.h"
+#include "../src/core/master_delivery.h"
+
+using dice::master_delivery::Recipient;
+
+TEST(MasterDelivery, GroupsBoundRealQQAndOpenId) {
+    const auto groups = dice::master_delivery::groupRecipients({
+        {"onebot_v11", "napcat", "123456789", "123456789"},
+        {"qq_official", "official", "open-id", "123456789"},
+    });
+    ASSERT_EQ(groups.size(), 1u);
+    ASSERT_EQ(groups.front().size(), 2u);
+}
+
+TEST(MasterDelivery, DoesNotGuessUnboundCrossPlatformIdentity) {
+    const auto groups = dice::master_delivery::groupRecipients({
+        {"onebot_v11", "napcat", "123456789", "123456789"},
+        {"qq_official", "official", "open-id", ""},
+        {"kook", "kook-bot", "123456789", ""},
+    });
+    ASSERT_EQ(groups.size(), 3u);
+}
+
+TEST(MasterDelivery, DeduplicatesExactEndpoint) {
+    const auto groups = dice::master_delivery::groupRecipients({
+        {"qq_official", "official", "open-id", ""},
+        {"qq_official", "official", "open-id", ""},
+    });
+    ASSERT_EQ(groups.size(), 1u);
+    ASSERT_EQ(groups.front().size(), 2u);
+}
+
+TEST(MasterDelivery, PrefersOneBotThenOfficial) {
+    const Recipient onebot{"onebot_v11", "napcat", "123456789", "123456789"};
+    const Recipient official{"qq_official", "official", "open-id", "123456789"};
+    ASSERT_TRUE(dice::master_delivery::transportPriority(onebot) <
+                dice::master_delivery::transportPriority(official));
+}


### PR DESCRIPTION
## Summary
- debounce transient adapter disconnects before reporting heartbeat offline
- reconnect QQ Official Gateway after unexpected socket closure
- deduplicate bound master delivery targets across linked QQ identities
- add focused regression tests for heartbeat debounce and master delivery

## Validation
- focused heartbeat debounce test: 10 assertions passed
- existing master delivery regression tests included in the branch