### PR TITLE
fix: preserve bot safety command prefixes

### DIFF
--- a/server/tests/test_import_v2.cpp
+++ b/server/tests/test_import_v2.cpp
@@ -741,8 +741,23 @@ TEST(BackupRestore, PartialArchiveOverlaysOnlySelectedContent) {
         Database db;
         ASSERT_TRUE(db.open("data/dice.db"));
         backup::Selection selection{};
-        selection.config = false; selection.databases = false; selection.logs = false;
-        selection.resources = false; selection.plugins = true; selection.media = false;
+        selection.config = false;
+        selection.coreDatabase = false;
+        selection.characterCards = false;
+        selection.chatHistory = false;
+        selection.gameLogs = false;
+        selection.runtimeLogs = false;
+        selection.auditLogs = false;
+        selection.decks = false;
+        selection.rules = false;
+        selection.help = false;
+        selection.cardTemplates = false;
+        selection.jsPlugins = true;
+        selection.luaMods = false;
+        selection.uploadedAssets = false;
+        selection.resourceImages = false;
+        selection.gameLogImages = false;
+        selection.chatMedia = false;
         ASSERT_TRUE(backup::createArchive(db, "config", archive, error, selection));
         db.close();
     }


### PR DESCRIPTION
## Summary
- always accept dot and Chinese full stop for bot status/control and dismiss commands
- keep all other commands bound to the owner-configured prefix list
- share the strict bot-control parser with the fallback prefix policy
- add regression coverage for both punctuation variants and invalid commands
- update the backup restore test to use the split backup selection fields

## Validation
- focused regression suite: 30 assertions passed
- git diff check passed